### PR TITLE
This code redirects input from 'input.in' and output to 'output.out' …

### DIFF
--- a/src/boilerplate.js
+++ b/src/boilerplate.js
@@ -28,6 +28,10 @@ void solve(){
 signed main() {
     ios_base::sync_with_stdio(false); 
     cin.tie(NULL);
+    #ifndef ONLINE_JUDGE
+    freopen("input.in", "r", stdin);
+    freopen("output.out", "w", stdout);
+    #endif
     int tst = 1;
     cin >> tst;
     while (tst--) {


### PR DESCRIPTION
…for local testing. It is ignored when running on an online judge platform where ONLINE_JUDGE is defined.